### PR TITLE
Dynamic appname & library ref update

### DIFF
--- a/demos/RestApplication/application/Init.php
+++ b/demos/RestApplication/application/Init.php
@@ -1,6 +1,12 @@
 <?php
 // Define Name of the application if not already done so.
 if (! defined('APP_NAME')) {
+    $appName = getenv('GLITCH_APP_NAME');
+    if (null != $appName)
+    {
+        define('APP_NAME', $appName);
+    }
+
     define('APP_NAME', 'DefaultApplication');
 }
 

--- a/demos/RestApplication/public/index.php
+++ b/demos/RestApplication/public/index.php
@@ -16,6 +16,7 @@
  * @version     $Id: index.php 7102 2010-09-25 14:00:10Z sdvalk $
  */
 
+// Used for log and cache. Remove if you want to use env. vars.
 define('APP_NAME', 'RestApplication');
 
 require_once '../application/Init.php';

--- a/demos/WebApplication/application/Init.php
+++ b/demos/WebApplication/application/Init.php
@@ -1,6 +1,12 @@
 <?php
 // Define Name of the application if not already done so.
 if (! defined('APP_NAME')) {
+    $appName = getenv('GLITCH_APP_NAME');
+    if (null != $appName)
+    {
+        define('APP_NAME', $appName);
+    }
+
     define('APP_NAME', 'DefaultApplication');
 }
 

--- a/demos/WebApplication/public/index.php
+++ b/demos/WebApplication/public/index.php
@@ -16,6 +16,7 @@
  * @version     $Id: index.php 7102 2010-09-25 14:00:10Z sdvalk $
  */
 
+// Used for log and cache. Remove if you want to use env. vars.
 define('APP_NAME', 'glitch3_web_application'); //please don't use spaces
 
 require_once '../application/Init.php';


### PR DESCRIPTION
The application name is now dynamic.
In both app examples the application name must be hardcoded. However, this causes caching problems when you deploy the same code multiple times to the same server. For instance when using the ShMem (or similar) caching back-end.

Also, i updated the ref to the approperiate Glitch library version. The unit tests were failing at my first checkout, updating library code to the latest release-3.0 helped.
